### PR TITLE
configuration for supporting non-s3 binary repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fsryan-gradle-publishing
 A gradle plugin for publishing libraries
 
-Currently, you can use this plugin to publish either jar or aar artifacts. This means you can write your project in Java/Kotlin/Groovy/etc. and deploy a binary artifact to an S3 repo.
+Currently, you can use this plugin to publish either jar or aar artifacts. This means you can write your project in Java/Kotlin/Groovy/etc. and deploy a binary artifact to an S3 repo or any repo you can connect to with basic authentication.
 
 ## How to use
 1. In your project's root build.gradle file, add the following:
@@ -9,12 +9,23 @@ Currently, you can use this plugin to publish either jar or aar artifacts. This 
 buildscript {
   repositories {
     jcenter()
+    // IF USING S3 as your maven backing
     maven {
       url 's3://your S3 bucket'
       authentication {
         credentials(AwsCredentials) {
           accessKey = /* your access key here, but you shouldn't store in source control */
           secretKey = /* your secret key here, but you shouldn't store in source control */
+        }
+      }
+    }
+    // IF USING some other repository as your maven backing
+    maven {
+      url 'https://your maven repository'
+      authentication {
+        credentials(PasswordCredentials) {
+          username = /* your user name--okay to store in storage control */
+          password = /* your password, but you shouldn't store in source control */
         }
       }
     }
@@ -42,6 +53,9 @@ fsPublishingConfig {
   baseArtifactId /* the name of your library */
   groupId project.group                                     // <-- the group name (such as com.fsryan)
   versionName project.version                               // <-- the version name (such as semantic version 1.0.3)
+  awsAccessKeyId = /* your access key here, but you shouldn't store in source control */
+  awsSecretKey = /* your secret key here, but you shouldn't store in source control */
+  basic
   extraPomProperties = [                                    // <-- all of the extra pom properties to add
     'myproj.gitHash': getGitHash()                          // <-- assuming you can get the git hash
   ]

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group 'com.fsryan.gradle'
-version '0.0.6'
+version '0.1.0'
 
 repositories {
     jcenter()

--- a/src/main/groovy/com/fsryan/gradle/FSPublishingExtension.groovy
+++ b/src/main/groovy/com/fsryan/gradle/FSPublishingExtension.groovy
@@ -15,8 +15,40 @@ class FSPublishingExtension {
     String snapshotRepoName = 'snapshot'
     String snapshotRepoUrl
     String description = ""
+    /**
+     * Your AWS access key id--which you configure via the AWS console
+     */
     String awsAccessKeyId
+    /**
+     * Your AWS secret key--which you configure via the AWS console.
+     */
     String awsSecretKey
+    /**
+     * If you want to use basic creds, then you should use this. Additionally,
+     * you should flip {@link #useBasicCredentials} to false.
+     */
+    String releaseBasicUser
+    /**
+     * If you want to use basic creds, then you should use this. Additionally,
+     * you should flip {@link #useBasicCredentials} to false.
+     */
+    String releaseBasicPassword
+    /**
+     * If you want to use basic creds, then you should use this. Additionally,
+     * you should flip {@link #useBasicCredentials} to false.
+     */
+    String snapshotBasicUser
+    /**
+     * If you want to use basic creds, then you should use this. Additionally,
+     * you should flip {@link #useBasicCredentials} to false.
+     */
+    String snapshotBasicPassword
+    /**
+     * Set this if you want to use basic credentials instead of the
+     * previously-supported AWS credentials. Defaults to false for
+     * compatibility.
+     */
+    boolean useBasicCredentials = false
     List<String> additionalPublications = new ArrayList<>()
     /**
      * <p>If you want to add properties to the pom, then you can do so via this
@@ -49,5 +81,25 @@ class FSPublishingExtension {
     FSPublishingExtension(Project project) {
         groupId = project.group
         versionName = project.name
+    }
+
+    boolean hasReleaseBasicCreds() {
+        return releaseBasicUser != null && releaseBasicPassword != null
+    }
+
+    boolean hasAwsCreds() {
+        return awsAccessKeyId != null && awsSecretKey != null
+    }
+
+    boolean hasSnapshotBasicCreds() {
+        return snapshotBasicUser != null && snapshotBasicPassword != null
+    }
+
+    boolean releaseRepositoryConfigured() {
+        return releaseRepoUrl != null && (hasReleaseBasicCreds() || hasAwsCreds())
+    }
+
+    boolean snapshotRepositoryConfigured() {
+        return snapshotRepoUrl != null && (hasSnapshotBasicCreds() || hasAwsCreds())
     }
 }

--- a/src/main/groovy/com/fsryan/gradle/FSPublishingPlugin.groovy
+++ b/src/main/groovy/com/fsryan/gradle/FSPublishingPlugin.groovy
@@ -3,13 +3,12 @@ package com.fsryan.gradle
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.credentials.AwsCredentials
+import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.Set
-import java.util.HashSet
 
 class FSPublishingPlugin implements Plugin<Project> {
 
@@ -39,20 +38,47 @@ class FSPublishingPlugin implements Plugin<Project> {
 
             project.publishing {
                 repositories {
-                    maven {
-                        name fsPublishingExt.releaseRepoName
-                        url fsPublishingExt.releaseRepoUrl
-                        credentials(AwsCredentials) {
-                            accessKey = fsPublishingExt.awsAccessKeyId
-                            secretKey = fsPublishingExt.awsSecretKey
+                    if (fsPublishingExt.useBasicCredentials) {
+                        if (fsPublishingExt.releaseRepositoryConfigured()) {
+                            maven {
+                                name fsPublishingExt.releaseRepoName
+                                url fsPublishingExt.releaseRepoUrl
+                                credentials(PasswordCredentials) {
+                                    username = fsPublishingExt.releaseBasicUser
+                                    password = fsPublishingExt.releaseBasicPassword
+                                }
+                            }
                         }
-                    }
-                    maven {
-                        name fsPublishingExt.snapshotRepoName
-                        url fsPublishingExt.snapshotRepoUrl
-                        credentials(AwsCredentials) {
-                            accessKey = fsPublishingExt.awsAccessKeyId
-                            secretKey = fsPublishingExt.awsSecretKey
+                        if (fsPublishingExt.snapshotRepositoryConfigured()) {
+                            maven {
+                                name fsPublishingExt.snapshotRepoName
+                                url fsPublishingExt.snapshotRepoUrl
+                                credentials(PasswordCredentials) {
+                                    username = fsPublishingExt.awsAccessKeyId
+                                    password = fsPublishingExt.awsSecretKey
+                                }
+                            }
+                        }
+                    } else {
+                        if (fsPublishingExt.releaseRepositoryConfigured()) {
+                            maven {
+                                name fsPublishingExt.releaseRepoName
+                                url fsPublishingExt.releaseRepoUrl
+                                credentials(AwsCredentials) {
+                                    accessKey = fsPublishingExt.awsAccessKeyId
+                                    secretKey = fsPublishingExt.awsSecretKey
+                                }
+                            }
+                        }
+                        if (fsPublishingExt.snapshotRepositoryConfigured()) {
+                            maven {
+                                name fsPublishingExt.snapshotRepoName
+                                url fsPublishingExt.snapshotRepoUrl
+                                credentials(AwsCredentials) {
+                                    accessKey = fsPublishingExt.awsAccessKeyId
+                                    secretKey = fsPublishingExt.awsSecretKey
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This is a pretty terrible addition to an already crufty plugin. That's saying a lot for such a small repo. I wish I had better code, but as long as I can continue to maintain this, I think I'm going to stick with it.